### PR TITLE
Support passing GCP credentials as JSON in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,22 @@ project=
 # The name of the BigQuery dataset to write to (leave the '.*=' at the beginning, enter your
 # dataset after it)
 datasets=.*=
-# The location of a BigQuery service account JSON key file
+# The location of a GCP service account credentials file or a user credentials file in JSON format
 keyfile=
+# GCP service account credentials or user credentials in JSON format (non-escaped JSON blob)
+credentials=
 ```
 
 You'll need to choose a BigQuery project to write to, a dataset from that project to write to, and
-provide the location of a JSON key file that can be used to access a BigQuery service account that
-can write to the project/dataset pair. Once you've decided on these properties, fill them in and
-save the properties file.
+provide GCP credentials that can be used to access a BigQuery service account that can write
+to the project/dataset pair. This can be done in two ways:
+- by providing the name of a key file using `keyfile` parameter; or
+- by providing the credentials explicitly as a JSON string (a non-escaped JSON blob) using
+`credentials` parameter.
+
+When specified, `credentials` has priority over `keyfile`.
+
+Once you've decided on these properties, fill them in and save the properties file.
 
 Once you get more familiar with the connector, you might want to revisit the `connector.properties`
 file and experiment with tweaking its settings.
@@ -139,11 +147,13 @@ Integration tests run by creating [Docker] instances for [Zookeeper], [Kafka], [
 and the BigQuery Connector itself, then verifying the results using a [JUnit] test.
 
 They use schemas and data that can be found in the `test/docker/populate/test_schemas/` directory, 
-and rely on a user-provided JSON key file (like in the `quickstart` example) to access BigQuery.
+and rely on a user-provided JSON key file (like in the `quickstart` example) or explicit JSON
+credentials to access BigQuery.
 
-The project and dataset they write to, as well as the specific JSON key file they use, can be
-specified by command-line flag, environment variable, or configuration file — the exact details of
-each can be found by running the integration test script with the `-?` flag.
+The project and dataset they write to, as well as the specific JSON key file or JSON credentials
+string they use, can be specified by command-line flag, environment variable,
+or configuration file — the exact details of each can be found by running the integration
+test script with the `-?` flag.
 
 ### Data Corruption Concerns
 

--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,7 @@ project(':kcbq-connector') {
         main = 'com.wepay.kafka.connect.bigquery.it.utils.TableClearer'
         classpath = sourceSets.integrationTest.runtimeClasspath
         args findProperty('kcbq_test_keyfile') ?: ''
+        args findProperty('kcbq_test_credentials') ?: ''
         args findProperty('kcbq_test_project') ?: ''
         args findProperty('kcbq_test_dataset') ?: ''
         if (findProperty('kcbq_test_tables') != null)
@@ -160,6 +161,7 @@ project(':kcbq-connector') {
         main = 'com.wepay.kafka.connect.bigquery.it.utils.BucketClearer'
         classpath = sourceSets.integrationTest.runtimeClasspath
         args findProperty('kcbq_test_keyfile') ?: ''
+        args findProperty('kcbq_test_credentials') ?: ''
         args findProperty('kcbq_test_project') ?: ''
         args findProperty('kcbq_test_bucket') ?: ''
     }

--- a/kcbq-connector/quickstart/properties/connector.properties
+++ b/kcbq-connector/quickstart/properties/connector.properties
@@ -36,5 +36,7 @@ project=
 # The name of the BigQuery dataset to write to (leave the '.*=' at the beginning, enter your
 # dataset after it)
 datasets=.*=
-# The location of a BigQuery service account JSON key file
+# The location of a GCP service account credentials file or a user credentials file in JSON format
 keyfile=
+# GCP service account credentials or user credentials in JSON format (non-escaped JSON blob)
+credentials=

--- a/kcbq-connector/src/integration-test/java/com/wepay/kafka/connect/bigquery/it/utils/BucketClearer.java
+++ b/kcbq-connector/src/integration-test/java/com/wepay/kafka/connect/bigquery/it/utils/BucketClearer.java
@@ -18,10 +18,10 @@ package com.wepay.kafka.connect.bigquery.it.utils;
  */
 
 
-import com.google.cloud.storage.Bucket;
-
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Storage;
 import com.wepay.kafka.connect.bigquery.GCSBuilder;
+import com.wepay.kafka.connect.bigquery.GoogleCredentialsReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,17 +30,28 @@ public class BucketClearer {
   private static final Logger logger = LoggerFactory.getLogger(BucketClearer.class);
 
   /**
-   * Clears tables in the given project and dataset, using a provided JSON service account key.
+   * Clears tables in the given project and dataset, using the provided credentials.
    */
   public static void main(String[] args) {
-    if (args.length < 3) {
+    if (args.length < 4) {
       usage();
     }
 
-    Storage gcs = new GCSBuilder(args[1]).setKeyFileName(args[0]).build();
+    String keyFile = args[0];
+    String credentialsStr = args[1];
+    String projectName = args[2];
+    String bucketName = args[3];
+
+    GoogleCredentials credentials = null;
+    if (!credentialsStr.isEmpty()) {
+      credentials = GoogleCredentialsReader.fromJsonString(credentialsStr);
+    } else if (!keyFile.isEmpty()) {
+      credentials = GoogleCredentialsReader.fromJsonFile(keyFile);
+    }
+
+    Storage gcs = new GCSBuilder(projectName).setCredentials(credentials).build();
 
     // if bucket exists, delete it.
-    String bucketName = args[2];
     if (gcs.delete(bucketName)) {
       logger.info("Bucket {} deleted successfully", bucketName);
     } else {
@@ -50,7 +61,8 @@ public class BucketClearer {
 
   private static void usage() {
     System.err.println(
-        "usage: BucketClearer <key_file> <project_name> <bucket_name>"
+        "usage: BucketClearer <key_file> <credentials> <project_name> <bucket_name>\n" +
+            "<credentials> has priority over <key_file>."
     );
     System.exit(1);
   }

--- a/kcbq-connector/src/integration-test/java/com/wepay/kafka/connect/bigquery/it/utils/TableClearer.java
+++ b/kcbq-connector/src/integration-test/java/com/wepay/kafka/connect/bigquery/it/utils/TableClearer.java
@@ -18,9 +18,11 @@ package com.wepay.kafka.connect.bigquery.it.utils;
  */
 
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.BigQuery;
 
 import com.wepay.kafka.connect.bigquery.BigQueryHelper;
+import com.wepay.kafka.connect.bigquery.GoogleCredentialsReader;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,25 +31,39 @@ public class TableClearer {
   private static final Logger logger = LoggerFactory.getLogger(TableClearer.class);
 
   /**
-   * Clears tables in the given project and dataset, using a provided JSON service account key.
+   * Clears tables in the given project and dataset, using the provided credentials.
    */
   public static void main(String[] args) {
-    if (args.length < 4) {
+    if (args.length < 5) {
       usage();
     }
-    BigQuery bigQuery = new BigQueryHelper().connect(args[1], args[0]);
-    for (int i = 3; i < args.length; i++) {
-      if (bigQuery.delete(args[2], args[i])) {
-        logger.info("Table {} in dataset {} deleted successfully", args[i], args[2]);
+
+    String keyFile = args[0];
+    String credentialsStr = args[1];
+    String projectName = args[2];
+    String dataSet = args[3];
+
+    GoogleCredentials credentials = null;
+    if (!credentialsStr.isEmpty()) {
+      credentials = GoogleCredentialsReader.fromJsonString(credentialsStr);
+    } else if (!keyFile.isEmpty()) {
+      credentials = GoogleCredentialsReader.fromJsonFile(keyFile);
+    }
+
+    BigQuery bigQuery = new BigQueryHelper().connect(projectName, credentials);
+    for (int i = 4; i < args.length; i++) {
+      if (bigQuery.delete(dataSet, args[i])) {
+        logger.info("Table {} in dataset {} deleted successfully", args[i], dataSet);
       } else {
-        logger.info("Table {} in dataset {} does not exist", args[i], args[2]);
+        logger.info("Table {} in dataset {} does not exist", args[i], dataSet);
       }
     }
   }
 
   private static void usage() {
     System.err.println(
-        "usage: TableClearer <key_file> <project_name> <dataset_name> <table> [<table> ...]"
+        "usage: TableClearer <key_file> <credentials> <project_name> <dataset_name> <table> [<table> ...]\n" +
+            "<credentials> has priority over <key_file>."
     );
     System.exit(1);
   }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQueryHelper.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQueryHelper.java
@@ -43,28 +43,21 @@ public class BigQueryHelper {
    * from specific datasets.
    *
    * @param projectName The name of the BigQuery project to work with
-   * @param keyFilename The name of a file containing a JSON key that can be used to provide
-   *                    credentials to BigQuery, or null if no authentication should be performed.
+   * @param credentials BigQuery credentials, or null if no authentication should be performed.
    * @return The resulting BigQuery object.
    */
-  public BigQuery connect(String projectName, String keyFilename) {
-    if (keyFilename == null) {
+  public BigQuery connect(String projectName, GoogleCredentials credentials) {
+    if (credentials == null) {
       return connect(projectName);
     }
 
-    logger.debug("Attempting to open file {} for service account json key", keyFilename);
-    try (InputStream credentialsStream = new FileInputStream(keyFilename)) {
-      logger.debug("Attempting to authenticate with BigQuery using provided json key");
-      return new
-          BigQueryOptions.DefaultBigQueryFactory().create(
-          BigQueryOptions.newBuilder()
-          .setProjectId(projectName)
-          .setCredentials(GoogleCredentials.fromStream(credentialsStream))
-          .build()
-      );
-    } catch (IOException err) {
-      throw new BigQueryConnectException("Failed to access json key file", err);
-    }
+    logger.debug("Attempting to authenticate with BigQuery using provided credentials");
+    return new BigQueryOptions.DefaultBigQueryFactory().create(
+        BigQueryOptions.newBuilder()
+        .setProjectId(projectName)
+        .setCredentials(credentials)
+        .build()
+    );
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
@@ -18,6 +18,7 @@ package com.wepay.kafka.connect.bigquery;
  */
 
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.TableId;
 
@@ -91,8 +92,8 @@ public class BigQuerySinkConnector extends SinkConnector {
       return testBigQuery;
     }
     String projectName = config.getString(config.PROJECT_CONFIG);
-    String keyFilename = config.getString(config.KEYFILE_CONFIG);
-    return new BigQueryHelper().connect(projectName, keyFilename);
+    GoogleCredentials credentials = config.getCredentials();
+    return new BigQueryHelper().connect(projectName, credentials);
   }
 
   private SchemaManager getSchemaManager(BigQuery bigQuery) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -18,6 +18,7 @@ package com.wepay.kafka.connect.bigquery;
  */
 
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
 import com.google.cloud.bigquery.TableId;
@@ -230,8 +231,8 @@ public class BigQuerySinkTask extends SinkTask {
       return testBigQuery;
     }
     String projectName = config.getString(config.PROJECT_CONFIG);
-    String keyFilename = config.getString(config.KEYFILE_CONFIG);
-    return new BigQueryHelper().connect(projectName, keyFilename);
+    GoogleCredentials credentials = config.getCredentials();
+    return new BigQueryHelper().connect(projectName, credentials);
   }
 
   private SchemaManager getSchemaManager(BigQuery bigQuery) {
@@ -261,8 +262,8 @@ public class BigQuerySinkTask extends SinkTask {
       return testGcs;
     }
     String projectName = config.getString(config.PROJECT_CONFIG);
-    String keyFilename = config.getString(config.KEYFILE_CONFIG);
-    return new GCSBuilder(projectName).setKeyFileName(keyFilename).build();
+    GoogleCredentials credentials = config.getCredentials();
+    return new GCSBuilder(projectName).setCredentials(credentials).build();
   }
 
   private GCSToBQWriter getGcsWriter() {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GoogleCredentialsReader.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GoogleCredentialsReader.java
@@ -1,0 +1,49 @@
+package com.wepay.kafka.connect.bigquery;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Reads Google credentials from different sources.
+ */
+public class GoogleCredentialsReader {
+    private static final Logger logger = LoggerFactory.getLogger(GoogleCredentialsReader.class);
+
+    /**
+     * Returns {@link GoogleCredentials} defined by a service account credentials file or
+     * user credentials file in JSON format.
+     * @param filename the name of the file.
+     * @return the credential defined by the file.
+     * @throws BigQueryConnectException if the credential cannot be created from the file.
+     */
+    public static GoogleCredentials fromJsonFile(String filename) {
+        logger.debug("Attempting to open credentials file {}", filename);
+        try (InputStream stream = new FileInputStream(filename)) {
+            return GoogleCredentials.fromStream(stream);
+        } catch (IOException err) {
+            throw new BigQueryConnectException("Failed to read credentials from file", err);
+        }
+    }
+
+    /**
+     * Returns {@link GoogleCredentials} defined by a service account credentials or
+     * user credentials in JSON format.
+     * @param jsonString the string with the credentials.
+     * @return the credential defined by the JSON string.
+     * @throws BigQueryConnectException if the credential cannot be created from the string.
+     */
+    public static GoogleCredentials fromJsonString(String jsonString) {
+        try (InputStream stream = new ByteArrayInputStream(jsonString.getBytes())) {
+            return GoogleCredentials.fromStream(stream);
+        } catch (IOException err) {
+            throw new BigQueryConnectException("Failed to read credentials from JSON string", err);
+        }
+    }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -18,8 +18,10 @@ package com.wepay.kafka.connect.bigquery.config;
  */
 
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.Schema;
 
+import com.wepay.kafka.connect.bigquery.GoogleCredentialsReader;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 
 import com.wepay.kafka.connect.bigquery.convert.BigQueryRecordConverter;
@@ -122,7 +124,15 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final String KEYFILE_DEFAULT =                    null;
   private static final ConfigDef.Importance KEYFILE_IMPORTANCE =  ConfigDef.Importance.MEDIUM;
   private static final String KEYFILE_DOC =
-      "The file containing a JSON key with BigQuery service account credentials";
+      "The file with GCP service account credentials or user credentials in JSON format";
+
+  public static final String CREDENTIALS_CONFIG =                    "credentials";
+  private static final ConfigDef.Type CREDENTIALS_TYPE =             ConfigDef.Type.STRING;
+  public static final String CREDENTIALS_DEFAULT =                   null;
+  private static final ConfigDef.Importance CREDENTIALS_IMPORTANCE = ConfigDef.Importance.MEDIUM;
+  private static final String CREDENTIALS_DOC =
+      "GCP service account credentials or user credentials in in JSON format (non-escaped JSON blob). " +
+          "Has priority over credentials provided by keyfile.";
 
   public static final String SANITIZE_TOPICS_CONFIG =                     "sanitizeTopics";
   private static final ConfigDef.Type SANITIZE_TOPICS_TYPE =              ConfigDef.Type.BOOLEAN;
@@ -225,6 +235,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
             KEYFILE_DEFAULT,
             KEYFILE_IMPORTANCE,
             KEYFILE_DOC
+        ).define(
+            CREDENTIALS_CONFIG,
+            CREDENTIALS_TYPE,
+            CREDENTIALS_DEFAULT,
+            CREDENTIALS_IMPORTANCE,
+            CREDENTIALS_DOC
         ).define(
             SANITIZE_TOPICS_CONFIG,
             SANITIZE_TOPICS_TYPE,
@@ -490,6 +506,25 @@ public class BigQuerySinkConfig extends AbstractConfig {
     schemaRetriever.configure(originalsStrings());
 
     return schemaRetriever;
+  }
+
+  /**
+   * Returns {@link GoogleCredentials} defined in the configuration.
+   *
+   * @return An object of {@link GoogleCredentials} created based on the configuration,
+   *         or null if there's no credentials in the configuration.
+   */
+  public GoogleCredentials getCredentials() {
+    String credentials = getString(CREDENTIALS_CONFIG);
+    String keyFile = getString(KEYFILE_CONFIG);
+
+    if (credentials != null && !credentials.isEmpty()) {
+      return GoogleCredentialsReader.fromJsonString(credentials);
+    } else if (keyFile != null && !keyFile.isEmpty()) {
+      return GoogleCredentialsReader.fromJsonFile(keyFile);
+    } else {
+      return null;
+    }
   }
 
   /**

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkPropertiesFactory.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkPropertiesFactory.java
@@ -63,6 +63,7 @@ public class SinkPropertiesFactory {
     config.getList(config.DATASETS_CONFIG);
 
     config.getString(config.KEYFILE_CONFIG);
+    config.getString(config.CREDENTIALS_CONFIG);
     config.getString(config.PROJECT_CONFIG);
 
     config.getBoolean(config.SANITIZE_TOPICS_CONFIG);

--- a/kcbq-connector/test/integrationtest.sh
+++ b/kcbq-connector/test/integrationtest.sh
@@ -34,19 +34,23 @@ YELLOW='\033[1;33m'
 usage() {
   echo -e "usage: $0\n" \
        "[-k|--key-file <JSON key file>] (path must be absolute; relative paths will not work)\n" \
+       "[-c|--credentials <credentials in JSON format (quoted JSON blob)>]\n" \
        "[-p|--project <BigQuery project>]\n" \
        "[-d|--dataset <BigQuery project>]\n" \
        "[-b|--bucket <cloud Storage bucket>\n]" \
        1>&2
   echo 1>&2
   echo "Options can also be specified via environment variable:" \
-       "KCBQ_TEST_KEYFILE, KCBQ_TEST_PROJECT, KCBQ_TEST_DATASET, and KCBQ_TEST_BUCKET" \
-       "respectively control the keyfile, project, dataset, and bucket." \
+       "KCBQ_TEST_KEYFILE, KCBQ_TEST_CREDENTIALS, KCBQ_TEST_PROJECT, KCBQ_TEST_DATASET, and KCBQ_TEST_BUCKET" \
+       "respectively control the keyfile, credentials, project, dataset, and bucket." \
        1>&2
   echo 1>&2
   echo "Options can also be specified in a file named 'test.conf'" \
        "placed in the same directory as this script, with a series of <property>=<value> lines." \
-       "The properties are 'keyfile', 'project', 'dataset', and 'bucket'." \
+       "The properties are 'keyfile', 'credentials', 'project', 'dataset', and 'bucket'." \
+       1>&2
+  echo 1>&2
+  echo "The credentials specified by 'credentials' have priority over the credentials provided by the file from 'keyfile'." \
        1>&2
   echo 1>&2
   echo "The descending order of priority for each of these forms of specification is:" \
@@ -97,6 +101,7 @@ PROPERTIES_FILE="$BASE_DIR/test.conf"
 # Copy the file's properties into actual test variables,
 # without overriding any that have already been specified
 KCBQ_TEST_KEYFILE=${KCBQ_TEST_KEYFILE:-$keyfile}
+KCBQ_TEST_CREDENTIALS=${KCBQ_TEST_CREDENTIALS:-$credentials}
 KCBQ_TEST_PROJECT=${KCBQ_TEST_PROJECT:-$project}
 KCBQ_TEST_DATASET=${KCBQ_TEST_DATASET:-$dataset}
 KCBQ_TEST_BUCKET=${KCBQ_TEST_BUCKET:-$bucket}
@@ -108,6 +113,11 @@ while [[ $# -gt 0 ]]; do
         [[ -z "$2" ]] && { error "key filename must follow $1 flag"; usage 1; }
         shift
         KCBQ_TEST_KEYFILE="$1"
+        ;;
+    -c|--credentials)
+        [[ -z "$2" ]] && { error "credentials must follow $1 flag"; usage 1; }
+        shift
+        KCBQ_TEST_CREDENTIALS="$1"
         ;;
     -p|--project)
         [[ -z "$2" ]] && { error "project name must follow $1 flag"; usage 1; }
@@ -135,7 +145,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Make sure required arguments have been provided one way or another
-[[ -z "$KCBQ_TEST_KEYFILE" ]] && { error 'a key filename is required'; usage 1; }
+[[ -z "$KCBQ_TEST_KEYFILE" ]] && [[ -z "$KCBQ_TEST_CREDENTIALS" ]] && { error 'a key filename or credentials JSON is required'; usage 1; }
 [[ -z "$KCBQ_TEST_PROJECT" ]] && { error 'a project name is required'; usage 1; }
 [[ -z "$KCBQ_TEST_DATASET" ]] && { error 'a dataset name is required'; usage 1; }
 [[ -z "$KCBQ_TEST_BUCKET" ]] && { error 'a bucket name is required'; usage 1; }
@@ -215,6 +225,7 @@ warn 'Deleting existing BigQuery test tables and existing GCS bucket'
 
 "$GRADLEW" -p "$BASE_DIR/.." \
     -Pkcbq_test_keyfile="$KCBQ_TEST_KEYFILE" \
+    -Pkcbq_test_credentials="$KCBQ_TEST_CREDENTIALS" \
     -Pkcbq_test_project="$KCBQ_TEST_PROJECT" \
     -Pkcbq_test_dataset="$KCBQ_TEST_DATASET" \
     -Pkcbq_test_tables="$(basename "$BASE_DIR"/resources/test_schemas/* | sed -E -e 's/[^a-zA-Z0-9_]/_/g' -e 's/^(.*)$/kcbq_test_\1/' | xargs echo -n)" \
@@ -251,11 +262,13 @@ basename "$BASE_DIR"/resources/test_schemas/* \
   >> "$CONNECTOR_PROPS"
 echo >> "$CONNECTOR_PROPS"
 
+echo "credentials=$KCBQ_TEST_CREDENTIALS" >> "$CONNECTOR_PROPS"
+
 CONNECT_DOCKER_IMAGE='kcbq/connect'
 CONNECT_DOCKER_NAME='kcbq_test_connect'
 
 cp "$BASE_DIR"/../../kcbq-confluent/build/distributions/kcbq-confluent-*.tar "$DOCKER_DIR/connect/kcbq.tar"
-cp "$KCBQ_TEST_KEYFILE" "$DOCKER_DIR/connect/key.json"
+[[ ! -z "$KCBQ_TEST_KEYFILE" ]] && cp "$KCBQ_TEST_KEYFILE" "$DOCKER_DIR/connect/key.json"
 
 if ! dockerimageexists "$CONNECT_DOCKER_IMAGE"; then
   docker build -q -t "$CONNECT_DOCKER_IMAGE" "$DOCKER_DIR/connect"
@@ -277,6 +290,7 @@ INTEGRATION_TEST_RESOURCE_DIR="$BASE_DIR/../src/integration-test/resources"
 INTEGRATION_TEST_PROPERTIES_FILE="$INTEGRATION_TEST_RESOURCE_DIR/test.properties"
 
 echo "keyfile=$KCBQ_TEST_KEYFILE" > "$INTEGRATION_TEST_PROPERTIES_FILE"
+echo "credentials=$KCBQ_TEST_CREDENTIALS" >> "$INTEGRATION_TEST_PROPERTIES_FILE"
 echo "project=$KCBQ_TEST_PROJECT" >> "$INTEGRATION_TEST_PROPERTIES_FILE"
 echo "dataset=$KCBQ_TEST_DATASET" >> "$INTEGRATION_TEST_PROPERTIES_FILE"
 echo "bucket=$KCBQ_TEST_BUCKET" >> "$INTEGRATION_TEST_PROPERTIES_FILE"


### PR DESCRIPTION
Support passing the GCP credentials via the configuration directive `credentials` as a non-escaped JSON blob.

This helps to run the Kafka connector when the environment can't be manipulated.

Changes:
- `credentials` configuration keys added. It has the priority over `keyfile` when provided.
- `GoogleCredentials` objects are now provided by `BigQuerySinkConfig.getCredentials`, which handles both `keyfile` and `credentials` configuration keys.
- The ability to use explicit JSON credentials added to the integration test suite:
  - support of `-c|--credentials` CLI parameter, `KCBQ_TEST_CREDENTIALS` environment variable, and `credentials` configuration key in `integrationtest.sh`; using them in all relevant pieces of config;
  - support of `kcbq_test_credentials` in `integrationTestPrep` Gradle task and passing it to `BucketClearer` and `TableClearer`.
- `README.md` updated.
